### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/tzmsky/4822d6e5-359f-41ff-b9c8-e2364eb99695/fcaec0e7-3b82-41aa-95d3-e02540182708/_apis/work/boardbadge/7f8cc458-a2b3-444d-a1d7-8541846daf24)](https://dev.azure.com/tzmsky/4822d6e5-359f-41ff-b9c8-e2364eb99695/_boards/board/t/fcaec0e7-3b82-41aa-95d3-e02540182708/Microsoft.RequirementCategory)
 # d.tzmsky.icu
 
 这是一个简陋的音游下载站，在未来我会添加csv文件让网站好看点，但是现在没时间，因为还有学业在身。


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#2](https://dev.azure.com/tzmsky/4822d6e5-359f-41ff-b9c8-e2364eb99695/_workitems/edit/2). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.